### PR TITLE
decouple troubleshooting docs into their own pages

### DIFF
--- a/flightcontrol.json
+++ b/flightcontrol.json
@@ -44,21 +44,6 @@
           "startCommand": "cd motif-docs && npm run start",
           "envVariables": {},
           "healthCheckPath": "/docs"
-        },
-        {
-          "id": "studio",
-          "name": "studio",
-          "type": "fargate",
-          "buildType": "nixpacks",
-          "cpu": 0.25,
-          "memory": 0.5,
-          "minInstances": 2,
-          "maxInstances": 2,
-          "installCommand": "cd studio && yarn",
-          "buildCommand": "cd studio && npm run build",
-          "startCommand": "cd studio && npm run start",
-          "envVariables": {},
-          "healthCheckPath": "/studio"
         }
       ]
     },
@@ -109,21 +94,6 @@
           "startCommand": "cd motif-docs && yarn start",
           "envVariables": {},
           "healthCheckPath": "/"
-        },
-        {
-          "id": "studio",
-          "name": "studio",
-          "type": "fargate",
-          "buildType": "nixpacks",
-          "cpu": 0.25,
-          "memory": 0.5,
-          "minInstances": 1,
-          "maxInstances": 1,
-          "installCommand": "cd studio && yarn",
-          "buildCommand": "cd studio && npm run build",
-          "startCommand": "cd studio && npm run start",
-          "envVariables": {},
-          "healthCheckPath": "/studio"
         }
       ]
     }

--- a/motif-docs/motif.json
+++ b/motif-docs/motif.json
@@ -12,7 +12,9 @@
     "docs/http-api/authorization/api-keys": "http-api",
     "docs/http-api/cloudfront/cache-invalidation-api": "http-api",
     "docs/http-api/cloudfront/cache-invalidation-status-api": "http-api",
-    "docs/http-api": "http-api"
+    "docs/http-api": "http-api",
+    "troubleshooting": "documentation",
+    "troubleshooting/*": "documentation"
   },
   "head": [
     "<meta name='viewport' content='width=device-width, initial-scale=1.0' />",

--- a/motif-docs/pages/_app.tsx
+++ b/motif-docs/pages/_app.tsx
@@ -36,7 +36,6 @@ const getTemplateId = (pathname: string) => {
 
 const getTemplate = (pathname: string) => {
   const templateId = getTemplateId(pathname)
-  console.log(templateId)
   switch (templateId) {
     case 'documentation':
       return dynamic(() =>

--- a/motif-docs/pages/_app.tsx
+++ b/motif-docs/pages/_app.tsx
@@ -36,6 +36,7 @@ const getTemplateId = (pathname: string) => {
 
 const getTemplate = (pathname: string) => {
   const templateId = getTemplateId(pathname)
+  console.log(templateId)
   switch (templateId) {
     case 'documentation':
       return dynamic(() =>

--- a/motif-docs/pages/troubleshooting/concurrency-limit.mdx
+++ b/motif-docs/pages/troubleshooting/concurrency-limit.mdx
@@ -1,0 +1,25 @@
+---
+heading: Error handling
+title: Reached Concurrency Limit on the number of tasks
+---
+
+import { Image } from '@components/ui/image.mdx'
+
+If the user noticed this error in Fargate Service Events tab:
+
+> You've reached the limit on the number of tasks you can run concurrently
+
+#### Solution
+
+- In the same Region, go to the Services search box, and search for EC2
+- In EC2, start a new instance
+
+<Image className="rounded-primary mx-auto w-full max-w-[420px] border" src="https://res.cloudinary.com/djp21wtxm/image/upload/v1655158948/i682x546-1vpX25Xb22Ou_krbs3d.png" />
+
+- Choose the smallest instance size
+- Once the instance is created, tear it down
+- Deploy your application again
+
+This AWS official response:
+
+> You must activate the Region in which you want to run Fargate by launching an EC2 instance in that Region. Otherwise, you will experience a Fargate concurrent task limit issue. Launching an instance will enable you to run multiple concurrent Fargate tasks.

--- a/motif-docs/pages/troubleshooting/deployment-errors.mdx
+++ b/motif-docs/pages/troubleshooting/deployment-errors.mdx
@@ -1,0 +1,21 @@
+---
+heading: Error handling
+title: Deployment Errors
+---
+
+If the user is getting this error:
+
+```
+[
+  [
+    {
+      "type": "FARGATE_DEPLOY_ERROR",
+      "message": "Service could not reach steady state; rolled back to previuos version. Please check runtime logs."
+    }
+  ]
+]
+```
+
+1. Go to the ECS service and under tasks see if there are stopped instances lately and what might be causing that in that instance log.
+2. Check the events tab under the service for any errors
+3. Check if the HealthCheck is not correct

--- a/motif-docs/pages/troubleshooting/index.mdx
+++ b/motif-docs/pages/troubleshooting/index.mdx
@@ -4,61 +4,25 @@ heading: Support
 ---
 
 import { Collapse } from '@components/ui/collapse.mdx'
-import { Image } from '@components/ui/image.mdx'
+import DeploymentError from './deployment-errors.mdx'
+import ConcurrencyLimit from './concurrency-limit.mdx'
+import LongDeploys from './long-deploys.mdx'
 
-<Collapse title="Unusually long deploys. Like 30 min instead of normal 10 min">
 
-Sometimes if you have multiple services and AWS is limiting the number of concurrent builds, it takes longer for your build to actually start.
+## Unusually long deploys. Like 30 min instead of normal 10 min
 
-You can check the build status by clicking on “Build Logs” in the Flightcontrol dashboard, then click on the “Phase Details” tab. There you can see which step of the build it’s currently stuck at.
+<LongDeploys />
 
-<Image className="rounded-primary mx-auto w-full max-w-[600px] border" src="https://res.cloudinary.com/djp21wtxm/image/upload/v1655158737/i1338x856-jthu6oejgKyd_ie4brq.png" />
 
-If you suspect a concurrent build quote issue, [you can submit a quota increase request here](https://console.aws.amazon.com/servicequotas/home/services/codebuild/quotas/L-75822022).
 
-</Collapse>
+## Deployment Errors
 
-<Collapse title="Deployment Errors">
+<DeploymentError />
 
-If the user is getting this error:
 
-```
-[
-  [
-    {
-      "type": "FARGATE_DEPLOY_ERROR",
-      "message": "Service could not reach steady state; rolled back to previuos version. Please check runtime logs."
-    }
-  ]
-]
-```
 
-1. Go to the ECS service and under tasks see if there are stopped instances lately and what might be causing that in that instance log.
-2. Check the events tab under the service for any errors
-3. Check if the HealthCheck is not correct
+## Reached Concurrency Limit on the number of tasks
 
-</Collapse>
+<ConcurrencyLimit />
 
-<Collapse title="Reached Concurrency Limit on the number of tasks">
-
-If the user noticed this error in Fargate Service Events tab:
-
-> You've reached the limit on the number of tasks you can run concurrently
-
-#### Solution
-
-- In the same Region, go to the Services search box, and search for EC2
-- In EC2, start a new instance
-
-<Image className="rounded-primary mx-auto w-full max-w-[420px] border" src="https://res.cloudinary.com/djp21wtxm/image/upload/v1655158948/i682x546-1vpX25Xb22Ou_krbs3d.png" />
-
-- Choose the smallest instance size
-- Once the instance is created, tear it down
-- Deploy your application again
-
-This AWS official response:
-
-> You must activate the Region in which you want to run Fargate by launching an EC2 instance in that Region. Otherwise, you will experience a Fargate concurrent task limit issue. Launching an instance will enable you to run multiple concurrent Fargate tasks.
-
-</Collapse>
 

--- a/motif-docs/pages/troubleshooting/long-deploys.mdx
+++ b/motif-docs/pages/troubleshooting/long-deploys.mdx
@@ -1,0 +1,14 @@
+---
+heading: Error handling
+title: Unusually long deploys. Like 30 min instead of normal 10 min
+---
+
+import { Image } from '@components/ui/image.mdx'
+
+Sometimes if you have multiple services and AWS is limiting the number of concurrent builds, it takes longer for your build to actually start.
+
+You can check the build status by clicking on “Build Logs” in the Flightcontrol dashboard, then click on the “Phase Details” tab. There you can see which step of the build it’s currently stuck at.
+
+<Image className="rounded-primary mx-auto w-full max-w-[600px] border" src="https://res.cloudinary.com/djp21wtxm/image/upload/v1655158737/i1338x856-jthu6oejgKyd_ie4brq.png" />
+
+If you suspect a concurrent build quote issue, [you can submit a quota increase request here](https://console.aws.amazon.com/servicequotas/home/services/codebuild/quotas/L-75822022).

--- a/motif-docs/project-config.ts
+++ b/motif-docs/project-config.ts
@@ -131,7 +131,7 @@ export default {
         title: 'API',
         href: '/http-api',
       },
-      { title: 'Troubleshooting', href: '/troubleshooting' },
+      { title: 'Troubleshooting', href: '/troubleshooting/concurrency-limit' },
       { title: 'Changelog', href: '/changelog' },
       // Add roadmap
       // { title: "Roadmap", href: "/roadmap" },
@@ -164,5 +164,24 @@ export default {
         ],
       },
     ],
+    'troubleshooting': [
+      {
+        title: 'Common Issues',
+        pages: [
+          {
+            title: 'Reached Concurrency Limit on the number of tasks',
+            href: '/troubleshooting/concurrency-limit',
+          },
+          {
+            title: 'Deployment Errors',
+            href: '/troubleshooting/deployment-errors',
+          },
+          {
+            title: 'Unusually long deploys. Like 30 min instead of normal 10 min',
+            href: '/troubleshooting/long-deploys',
+          },
+        ]
+      }    
+    ]
   },
 }


### PR DESCRIPTION
by @dillonraphael 

creating new PR to get preview env without the failed studio service