### PR TITLE
add docs for data dog env variables

### DIFF
--- a/motif-docs/motif.json
+++ b/motif-docs/motif.json
@@ -15,7 +15,7 @@
     "<meta name='viewport' content='width=device-width, initial-scale=1.0' />",
     "<meta name='og:title' content='Flightcontrol Docs' />",
     "<meta name='description' content='AWS Without Pain. Deploy, preview, & scale. DevOps not required. By the team behind Blitz.js' />",
-    "<link rel='shortcut icon' href='https://app.flightcontrol.dev/favicon.png' />",
+    "<link rel='shortcut icon' href='https://s.mkswft.com/RmlsZTpjYTkxN2M0ZC0zNzQyLTQ5MGMtYTJjMi02ZGQyNzU5ZTdhZTE=/favicon.png' />",
     "<link rel='preconnect' href='https://fonts.googleapis.com' />",
     "<link rel='preconnect' href='https://fonts.gstatic.com' crossorigin />",
     "<link href='https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;900&display=swap' rel='stylesheet' />",

--- a/motif-docs/pages/guides/datadog/support-for-fargate.mdx
+++ b/motif-docs/pages/guides/datadog/support-for-fargate.mdx
@@ -27,21 +27,23 @@ Here is a complete example:
     "com.datadoghq.ad.check_names": "[\"NAME\"]", // add the correct CheckNames
     "com.datadoghq.ad.init_configs": "[{}]"
   },
-  "experimental": { // make sure the datadog object is added under experimental
+  "experimental": {
+    // make sure the datadog object is added under experimental
     "datadog": {
       "enabled": true,
       "datadogSite": "us5.datadoghq.com", //plaintext
       "datadogApiKey": "DD_API_KEY.from.parameter.store", //from parameter store or secrets manager
-      "envVariables":{
+      "envVariables": {
         // Environment variables to pass to the datadog agent
-				// Similar to regular services variables
-				"DD_APM_ENABLED": true,
-				"ANOTHER_VARIABLE":{
-					"fromParameterStore": "parameter.store.name"
-				},
-				"THIRD_VARIABLE":{
-					"fromSecretsManager": "secrets.manager.arn"
-				}
+        // Similar to regular services variables
+        "DD_APM_ENABLED": true,
+        "ANOTHER_VARIABLE": {
+          "fromParameterStore": "parameter.store.name"
+        },
+        "THIRD_VARIABLE": {
+          "fromSecretsManager": "secrets.manager.arn"
+        }
+      }
     }
   }
 }

--- a/motif-docs/pages/guides/datadog/support-for-fargate.mdx
+++ b/motif-docs/pages/guides/datadog/support-for-fargate.mdx
@@ -31,7 +31,17 @@ Here is a complete example:
     "datadog": {
       "enabled": true,
       "datadogSite": "us5.datadoghq.com", //plaintext
-      "datadogApiKey": "DD_API_KEY.from.parameter.store" //from parameter store or secrets manager
+      "datadogApiKey": "DD_API_KEY.from.parameter.store", //from parameter store or secrets manager
+      "envVariables":{
+        // Environment variables to pass to the datadog agent
+				// Similar to regular services variables
+				"DD_APM_ENABLED": true,
+				"ANOTHER_VARIABLE":{
+					"fromParameterStore": "parameter.store.name"
+				},
+				"THIRD_VARIABLE":{
+					"fromSecretsManager": "secrets.manager.arn"
+				}
     }
   }
 }


### PR DESCRIPTION
This adds the missing section to configure datadog agent environment variables.