### PR TITLE
Fix undefined ref value

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,7 +7,9 @@ import '../lib/global.css'
 export default function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter()
   useEffect(() => {
-    document.cookie = `fc-referral-ref=${router.query.ref}; domain=flightcontrol.dev`
+    if (router.query.ref) {
+      document.cookie = `fc-referral-ref=${router.query.ref}; domain=flightcontrol.dev`
+    }
   }, [router.query.ref])
   return <Component {...pageProps} />
 }


### PR DESCRIPTION
Tested locally by using the docs site:
- `fc-referral-ref` value is no longer set to undefined if `?ref=` is not present
- `fc-referral-ref` is still set correctly if `?ref=` query is in URL