### PR TITLE
Add a note that docker build is supported for container services only

### DIFF
--- a/motif-docs/pages/guides/config/using-code.mdx
+++ b/motif-docs/pages/guides/config/using-code.mdx
@@ -189,6 +189,7 @@ The following properties are common for all service types:
   - This will be deprecated in favor of Nixpacks
 - Docker:
   - Bring your own Dockerfile for full control
+  - This is only supported for container based services like `fargate` and `fargate-worker`
 
 `watchPaths?: string[]`
 


### PR DESCRIPTION
This comes inline with the introduction of NixPacks support for static sites.