### PR TITLE
Fix previous/next links for documentation

### DIFF
--- a/motif-docs/components/app/app-footer.mdx
+++ b/motif-docs/components/app/app-footer.mdx
@@ -2,11 +2,11 @@ import { getPrevNext, getSidebarId } from '@lib/sidebar'
 
 import config from '/project-config'
 
-export const NextPrevLink = ({ slug, title, isPrev }) => {
+export const NextPrevLink = ({ href, title, isPrev }) => {
   return (
     <div className={!isPrev ? 'text-right' : ''}>
       <p className="text-gray-500 dark:text-white/50 text-sm mb-1">{isPrev ? 'Prev' : 'Next'}</p>
-      <a className="text-lg font-semibold hover:text-primary-600 transition" href={slug}>
+      <a className="text-lg font-semibold hover:text-primary-600 transition" href={href}>
         {title}
       </a>
     </div>
@@ -21,9 +21,9 @@ export default ({ path = '', basePath = '', includeNav = true }) => {
     <footer className="flex flex-col gap-12 z-20 antialiased mx-auto plain w-full pt-16 pb-16 mt-16 border-t border-gray-200 dark:border-white/10">
       {includeNav && (
         <div className="grid grid-cols-2">
-          <div>{prev && <NextPrevLink title={prev.title} slug={prev.slug} isPrev />}</div>
+          <div>{prev && <NextPrevLink title={prev.title} href={prev.href} isPrev />}</div>
           <div className="flex justify-end">
-            {next && <NextPrevLink title={next.title} slug={next.slug} />}
+            {next && <NextPrevLink title={next.title} href={next.href} />}
           </div>
         </div>
       )}

--- a/motif-docs/lib/types.ts
+++ b/motif-docs/lib/types.ts
@@ -1,6 +1,7 @@
 export type SidebarContent = SidebarSection[];
 
 export interface SidebarSection {
-  title?: string;
-  pages: (string | string[])[];
+  title: string;
+  href?: string;
+  pages?: SidebarSection[];
 }


### PR DESCRIPTION
When moving to the motif-docs the sidebar config structure was changed but the logic in sidebar.ts was not updated to handle the new structure.

This commit changes the logic to use the `href` values provided rather than trying to make the slug from the title since the manually chosen slug (i.e. the `href` value) is often different from a slugified title.

We also expand the logic to properly handle section overview pages (or lack thereof) and make sure that we don't cause errors for people manually manipulating the URL (e.g. `/docs/guides/get-started` -> `/docs/guides`).

The commit cleans up sidebar functions that are not used in the codebase to make maintenance easier for the next person.