### PR TITLE
Add basePath documentation

### DIFF
--- a/motif-docs/pages/guides/config/monorepos.mdx
+++ b/motif-docs/pages/guides/config/monorepos.mdx
@@ -57,7 +57,7 @@ If you don't use any sort of monorepo tooling at the root of your repo, then you
 
 ### Packages managed with monorepo tooling
 
-For JS monorepo that use `npm` and/or require installation at the root, you'll likely need to manually specify the install/build command AND account for the right path by `cd`'ing to the corresponding package, like so:
+For a JS monorepo using `npm` or a monorepo that requires running command from the root, you'll need to manually specify the install/build command AND account for the right path depending on the command needed, like so:
 
 ```json
 {
@@ -69,12 +69,11 @@ For JS monorepo that use `npm` and/or require installation at the root, you'll l
           "id": "api",
           "buildType": "nixpacks",
 
-          "installCommand": "npm i && cd packages/api && npm i"
-          "buildCommand": "cd packages/api && npm run build",
-          "startCommand": "cd packages/api && npm run start",
 
-          "installCommand": "cd .. && npm ci"
           "basePath": "./packages/api",
+          "installCommand": "cd .. && npm ci"
+          "startCommand": "npm run start",
+          "buildCommand": "npm run build",
           ...
 
         },
@@ -85,7 +84,7 @@ For JS monorepo that use `npm` and/or require installation at the root, you'll l
 }
 ```
 
-If you have a nx package-based monorepo, then you'll need to specify the `nx` command, including the package name, but you should not change the `basePath`:
+If you have a nx package-based monorepo, then you'll need to specify the `nx` command, including the package name, but you should not include or change the `basePath`:
 
 ```json
 {
@@ -109,13 +108,12 @@ If you have a nx package-based monorepo, then you'll need to specify the `nx` co
 
 ### Further customization
 
-If there are specific needs for building/installing a service, such as custom phases or specific OS packages, then you can use a `nixpacks.toml`.
-
+If there are specific needs for building/installing your service, such as custom phases or specific OS packages, then you can use a `nixpacks.toml`.
 The `.toml` file is specific to each package and should be placed in the package's folder.
 
 If you're using `basePath` in your flightcontrol configuration, you don't need to do anything else and the file will be picked up.
 
-If you're not using it, you'll need to set a `NIXPACKS_CONFIG_FILE` environment variable to the service's `nixpacks.toml` file path.
+If you're not using it, you'll need to set a `NIXPACKS_CONFIG_FILE` environment variable to the service's `nixpacks.toml` file path, like so:
 
 ```json
 {

--- a/motif-docs/pages/guides/config/monorepos.mdx
+++ b/motif-docs/pages/guides/config/monorepos.mdx
@@ -14,7 +14,7 @@ We cover a few cases below.
 
 ### Independent packages in a repo
 
-If you don't use any sort of monorepo tooling at the root of your repo, then you should indicate a `basePath` alongside the `[install|build|start]` commands, like illustrated in the contrived config example below.
+You should indicate a `basePath` alongside the `[install|build|start]` commands for each service, like illustrated in the contrived config example below.
 
 ```diff
 {

--- a/motif-docs/pages/guides/config/monorepos.mdx
+++ b/motif-docs/pages/guides/config/monorepos.mdx
@@ -69,8 +69,8 @@ For JS monorepo that use `npm` and/or require installation at the root, you'll l
           "buildCommand": "cd packages/api && npm run build",
           "startCommand": "cd packages/api && npm run start",
 
-          "basePath": "./",       // This is the default, no need to include it.
-                                     Left for illustration purpose
+          "basePath": ".",       // This is the default, no need to include it.
+                                    Left for illustration purpose
           ...
 
         },

--- a/motif-docs/pages/guides/config/monorepos.mdx
+++ b/motif-docs/pages/guides/config/monorepos.mdx
@@ -1,20 +1,118 @@
 ---
 heading: Configuration
-title: Monorepos Setup
+title: Monorepo Setup
 ---
 
-### Setting the commands in flightcontrol.json
+## Configuration File
 
-You can use a `flightcontrol.json` file at the repo root, but you'll need to account for the path of the corresponding package when specifying the commands for the services, like so:
+You can place the config file at the root of your repository and use it to configure each Flightcontrol service. See below some guidance on how to configure them.
 
-```json
-"buildCommand": "cd apps/frontend && npm run build",
-"startCommand": "cd apps/frontend && npm run start",
+## Using `buildType: nixpacks`
+
+There are different types of monorepos and tooling around it. Your configuration will depend on those.
+We cover a few cases below.
+
+### Independent packages in a repo
+
+If you don't use any sort of monorepo tooling at the root of your repo, then likely your configuration will only need to indicate a `basePath`, like illustrated in the contrived config example below.
+
+If for some reason `nixpacks` cannot identify the `[install|build|start]Command`, you'll then need to manually add it.
+
+```diff
+{
+  "environments": [
+    {
+      "id": "development",
+      "name": "Development",
+      "region": "us-east-2",
+      "source": {
+        "branch": "main"
+      },
+      "services": [
+        {
+          "id": "api",
+          "name": "Backend API",
+          "type": "fargate",
+          "buildType": "nixpacks",
+          "basePath": "./packages/api",
+          "healthCheckPath": "/graphql/health"
+        },
+        {
+          "id": "frontend",
+          "name": "Frontend Web",
+          "type": "static",
+          "singlePageApp": true,
+          "basePath": "./packages/frontend",
+          "outputDirectory": "web/dist",
+        }
+      ]
+    }
+  ]
+}
 ```
 
-### Using nixpacks config file
+### Packages managed with monorepo tooling
 
-If you want use a `nixpacks.toml` file in the packages of a monorepo, you'll need to have one individual `.toml` file for each package and then you'll need to add a `NIXPACKS_CONFIG_FILE` environment variable to the service with the file path.
+For JS monorepo that use `npm` and/or require installation at the root, you'll likely need to manually specify the install/build command AND account for the right path by `cd`'ing to the corresponding package, like so:
+
+```json
+{
+  "environments": [
+    {
+      ...
+      "services": [
+        {
+          "id": "api",
+          "buildType": "nixpacks",
+
+          "installCommand": "npm i && cd packages/api && npm i"
+          "buildCommand": "cd packages/api && npm run build",
+          "startCommand": "cd packages/api && npm run start",
+
+          "basePath": "./",       // This is the default, no need to include it.
+                                     Left for illustration purpose
+          ...
+
+        },
+        ...
+      ]
+    }
+  ]
+}
+```
+
+If you have a nx package-based monorepo, then you'll need to specify the `nx` command, including the package name, but you should not change the `basePath`:
+
+```json
+{
+  "environments": [
+    {
+      ...
+      "services": [
+        {
+          "id": "api",
+          "buildType": "nixpacks",
+          "buildCommand": "nx build blog",
+          "startCommand": "nx serve blog --verbose",
+          ...
+        },
+        ...
+      ]
+    }
+  ]
+}
+```
+
+### Further customization
+
+If there are specific needs for building/installing a service, such as custom phases or specific OS packages, then you can use a `nixpacks.toml`.
+
+For that, you'll need to:
+
+- Place the `nixpacks.toml` in the related package folder
+- Add a `NIXPACKS_CONFIG_FILE` environment variable to the service with the file path.
+
+Note: The `.toml` file is individual for each package.
 
 ```json
 {
@@ -27,15 +125,15 @@ If you want use a `nixpacks.toml` file in the packages of a monorepo, you'll nee
       envVariables": {
         "NIXPACKS_CONFIG_FILE": "./apps/frontend/nixpacks.toml"
       }
-      ...restOfConfig
+      ...
     },
     {
-      id: "backend",
+      id: "api",
       buildType: "nixpacks",
       envVariables": {
-        "NIXPACKS_CONFIG_FILE": "./apps/backend/nixpacks.toml"
+        "NIXPACKS_CONFIG_FILE": "./packages/api/nixpacks.toml"
       }
-      ...restOfConfig
+      ...
     },
   ],
 }

--- a/motif-docs/pages/guides/config/monorepos.mdx
+++ b/motif-docs/pages/guides/config/monorepos.mdx
@@ -14,9 +14,7 @@ We cover a few cases below.
 
 ### Independent packages in a repo
 
-If you don't use any sort of monorepo tooling at the root of your repo, then likely your configuration will only need to indicate a `basePath`, like illustrated in the contrived config example below.
-
-If for some reason `nixpacks` cannot identify the `[install|build|start]Command`, you'll then need to manually add it.
+If you don't use any sort of monorepo tooling at the root of your repo, then you should indicate a `basePath` alongside the `[install|build|start]` commands, like illustrated in the contrived config example below.
 
 ```diff
 {
@@ -35,7 +33,10 @@ If for some reason `nixpacks` cannot identify the `[install|build|start]Command`
           "type": "fargate",
           "buildType": "nixpacks",
           "basePath": "./packages/api",
-          "healthCheckPath": "/graphql/health"
+          "healthCheckPath": "/graphql/health",
+          "installCommand": "pnpm i"
+          "buildCommand": "pnpm build",
+          "startCommand": "pnpm start",
         },
         {
           "id": "frontend",
@@ -43,6 +44,9 @@ If for some reason `nixpacks` cannot identify the `[install|build|start]Command`
           "type": "static",
           "singlePageApp": true,
           "basePath": "./packages/frontend",
+          "installCommand": "pnpm i"
+          "buildCommand": "pnpm build",
+          "startCommand": "pnpm start",
           "outputDirectory": "web/dist",
         }
       ]
@@ -107,12 +111,11 @@ If you have a nx package-based monorepo, then you'll need to specify the `nx` co
 
 If there are specific needs for building/installing a service, such as custom phases or specific OS packages, then you can use a `nixpacks.toml`.
 
-For that, you'll need to:
+The `.toml` file is specific to each package and should be placed in the package's folder.
 
-- Place the `nixpacks.toml` in the related package folder
-- Add a `NIXPACKS_CONFIG_FILE` environment variable to the service with the file path.
+If you're using `basePath` in your flightcontrol configuration, you don't need to do anything else and the file will be picked up.
 
-Note: The `.toml` file is individual for each package.
+If you're not using it, you'll need to set a `NIXPACKS_CONFIG_FILE` environment variable to the service's `nixpacks.toml` file path.
 
 ```json
 {

--- a/motif-docs/pages/guides/config/monorepos.mdx
+++ b/motif-docs/pages/guides/config/monorepos.mdx
@@ -73,8 +73,8 @@ For JS monorepo that use `npm` and/or require installation at the root, you'll l
           "buildCommand": "cd packages/api && npm run build",
           "startCommand": "cd packages/api && npm run start",
 
-          "basePath": ".",       // This is the default, no need to include it.
-                                    Left for illustration purpose
+          "installCommand": "cd .. && npm ci"
+          "basePath": "./packages/api",
           ...
 
         },

--- a/motif-docs/pages/guides/config/using-code.mdx
+++ b/motif-docs/pages/guides/config/using-code.mdx
@@ -317,7 +317,6 @@ Besides the common properties above, each service will have specific properties,
     <Collapse title="Extra options for Nixpacks & Legacy Node.js">
         `basePath?: string` (only supported when `buildType: nixpacks`)
         - Allows you to specify in which folder the commands should run
-        - Only works with `buildType: nixpacks`
         - Example: `"basePath": "./apps"`
         - _Optional_, defaults to "./"
 
@@ -449,7 +448,6 @@ Besides the common properties above, each service will have specific properties,
     <Collapse title="Extra options for Nixpacks & Legacy Node.js">
         `basePath?: string` (only supported when `buildType: nixpacks`)
         - Allows you to specify in which folder the commands should run
-        - Only works with `buildType: nixpacks`
         - Example: `"basePath": "./apps"`
         - _Optional_, defaults to "./"
 
@@ -626,7 +624,6 @@ Besides the common properties above, each service will have specific properties,
 
     `basePath?: string` (only supported when `buildType: nixpacks`)
     - Allows you to specify in which folder the commands should run
-    - Only works with `buildType: nixpacks`
     - Example: `"basePath": "./apps"`
     - _Optional_, defaults to "./"
 

--- a/motif-docs/pages/guides/config/using-code.mdx
+++ b/motif-docs/pages/guides/config/using-code.mdx
@@ -190,6 +190,7 @@ The following properties are common for all service types:
 - Example: `"buildType": "nixpacks"`
 - Default: `'nodejs'`
 - Nixpacks:
+  - If you're using a monorepo, you'll likely want to pay attention to `basePath` and read [the guidance on monorepos](/guides/advanced/deploying-own-image)
   - Deploy almost any language without writing a Dockerfile!
   - Docs: [https://nixpacks.com/](https://nixpacks.com/)
   - You can customize native packages and such with [nixpacks.toml](https://nixpacks.com/docs/configuration/file)
@@ -314,6 +315,11 @@ Besides the common properties above, each service will have specific properties,
 
 
     <Collapse title="Extra options for Nixpacks & Legacy Node.js">
+        `basePath?: string` (only supported when `buildType: nixpacks`)
+
+        - Example: `"basePath": "./apps"`
+        - _Optional_, defaults to "./"
+
         `installCommand: string`
 
         - Example: `"installCommand": "./install.sh"`
@@ -419,7 +425,7 @@ Besides the common properties above, each service will have specific properties,
 
     - If using `buildType: fromService`, this is the ID of the service that you wish to use the image for.
 
-`containerImage: object`
+     `containerImage: object`
 
       - containerImage defines the parameters needed when using `buildType: fromRepository`
 
@@ -440,6 +446,11 @@ Besides the common properties above, each service will have specific properties,
         - This is the tag of the image from the repository that you would like to use
 
     <Collapse title="Extra options for Nixpacks & Legacy Node.js">
+        `basePath?: string` (only supported when `buildType: nixpacks`)
+
+        - Example: `"basePath": "./apps"`
+        - _Optional_, defaults to "./"
+
         `installCommand: string`
 
         - Example: `"installCommand": "./install.sh"`
@@ -611,6 +622,11 @@ Besides the common properties above, each service will have specific properties,
         - Mysql: `3306`
         - Mariadb: `3306`
 
+    `basePath?: string` (only supported when `buildType: nixpacks`)
+
+    - Example: `"basePath": "./apps"`
+    - _Optional_, defaults to "./"
+
 </Collapse>
 
 ### Redis
@@ -705,3 +721,8 @@ Note:
 ```
 
 </Collapse>
+
+## Config Example
+
+You can see an example config in this demo project:
+https://github.com/flightcontrolhq/demo-redwood/blob/main/flightcontrol.json

--- a/motif-docs/pages/guides/config/using-code.mdx
+++ b/motif-docs/pages/guides/config/using-code.mdx
@@ -316,7 +316,8 @@ Besides the common properties above, each service will have specific properties,
 
     <Collapse title="Extra options for Nixpacks & Legacy Node.js">
         `basePath?: string` (only supported when `buildType: nixpacks`)
-
+        - Allows you to specify in which folder the commands should run
+        - Only works with `buildType: nixpacks`
         - Example: `"basePath": "./apps"`
         - _Optional_, defaults to "./"
 
@@ -447,7 +448,8 @@ Besides the common properties above, each service will have specific properties,
 
     <Collapse title="Extra options for Nixpacks & Legacy Node.js">
         `basePath?: string` (only supported when `buildType: nixpacks`)
-
+        - Allows you to specify in which folder the commands should run
+        - Only works with `buildType: nixpacks`
         - Example: `"basePath": "./apps"`
         - _Optional_, defaults to "./"
 
@@ -623,7 +625,8 @@ Besides the common properties above, each service will have specific properties,
         - Mariadb: `3306`
 
     `basePath?: string` (only supported when `buildType: nixpacks`)
-
+    - Allows you to specify in which folder the commands should run
+    - Only works with `buildType: nixpacks`
     - Example: `"basePath": "./apps"`
     - _Optional_, defaults to "./"
 


### PR DESCRIPTION
## Description

Write up for the new supported field `basePath` that will allow people to specify in which folder the `nixpacks` build command should run. Mainly added for better supporting monorepos. 