### PR TITLE
ENG-1147: handling search when no search results present.

### DIFF
--- a/motif-docs/components/app/app-search.mdx
+++ b/motif-docs/components/app/app-search.mdx
@@ -60,19 +60,25 @@ export const SearchResults = ({
 }) => {
   return (
     <div className="flex flex-col p-3 bg-white dark:bg-gray-800 rounded-primary border border-gray-200 dark:border-white/10 antialiased">
-      {results.slice(0, limit || 5).map((result, i) => {
-        return (
-          <SearchResult
-            key={`search-result-${i}`}
-            selected={i === selectedIndex}
-            result={result}
-            onMouseOver={() => {
-              setSelectedIndex(i)
-            }}
-            onClick={onSubmit}
-          />
-        )
-      })}
+      {results.length > 0 ? (
+        results.slice(0, limit || 5).map((result, i) => {
+          return (
+            <SearchResult
+              key={`search-result-${i}`}
+              selected={i === selectedIndex}
+              result={result}
+              onMouseOver={() => {
+                setSelectedIndex(i)
+              }}
+              onClick={onSubmit}
+            />
+          )
+        })
+      ) : (
+        <div className="text-sm">
+          No results found
+        </div>
+      )}
     </div>
   )
 }
@@ -269,7 +275,7 @@ return (
   <div
   ref={searchResultsRef}
   className={cn('relative z-50', {
-  'opacity-0 pointer-events-none': state.results.length === 0,
+  'hidden': searchInputRef.current && searchInputRef.current.value.length === 0,  
   })} >
     <div className="z-50 sm:absolute left-0 right-[-320px] top-2">
       <SearchResults

--- a/motif-docs/components/app/app-search.mdx
+++ b/motif-docs/components/app/app-search.mdx
@@ -229,7 +229,9 @@ const onKeyDown = useCallback(
       break
     case 'Enter': {
       dispatch({ type: 'SET_RESULTS', results: [] })
-      window.open(window.__NEXT_DATA__.assetPrefix + state.results[state.selectedIndex]?.path, '\_self')
+      if(state.results.length) {
+        window.open(window.__NEXT_DATA__.assetPrefix + state.results[state.selectedIndex]?.path, '\_self')
+      }
       break
     }
     default:


### PR DESCRIPTION
## Before
There was no indication that the given search term doesn't exist. Using the `enter` key to search directed to 404 page. 
<img width="927" alt="Screenshot 2023-02-13 at 2 07 51 PM" src="https://user-images.githubusercontent.com/5904775/218564051-11480097-4029-4836-83a5-9c7686b7a1de.png">


## After
Now, when there are no search results for a query, using the `enter` key does nothing. The dropdown of search results shows a message that explains there are no results for the given search term.
<img width="942" alt="Screenshot 2023-02-13 at 2 07 35 PM" src="https://user-images.githubusercontent.com/5904775/218564017-f7be4d34-7d87-434a-95cf-0aa4f6bf04bb.png">

## Notes
I was going to just disable the enter key, but I believe explaining there are no results would be better for UX.

I had to change the `opacity-0` class logic in favor of using `hidden` because when there were no search results and the empty results message was visible, nav items behind the empty dropdown container could be clicked.
