### PR TITLE
Add overflow-x auto to Heroku comparison table

### DIFF
--- a/components/HerokuComparisonTable.tsx
+++ b/components/HerokuComparisonTable.tsx
@@ -18,22 +18,24 @@ export const HerokuComparisonTable = forwardRef(function HerokuComparisonTable()
     ];
     
     
-    return <table className={"w-full mx-20 border-collapse"}>
-        <thead>
-            <tr>
-                <th></th>
-                <th className={"text-white py-4 text-center"}>Flightcontrol</th>
-                <th className={"text-white py-4 text-center"}>Heroku</th>
-            </tr>
-        </thead>
-        <tbody>
-                { comparisonRows.map((row, key) => {
-                    return <tr key={key}>
-                        <td className={"text-slate-200 py-4 px-2 text-center border border-slate-400"}>{row[0]}</td>
-                        <td className={"text-slate-200 py-4 px-2 text-center border border-slate-400"}>{row[1]}</td>
-                        <td className={"text-slate-200 py-4 px-2 text-center border border-slate-400"}>{row[2]}</td>
-                    </tr>
-                }) }
-        </tbody>
-    </table>
+    return <div className={"w-full mx-5 overflow-x-auto"}>
+        <table className={"border-collapse"}>
+            <thead>
+                <tr>
+                    <th></th>
+                    <th className={"text-white py-4 text-center"}>Flightcontrol</th>
+                    <th className={"text-white py-4 text-center"}>Heroku</th>
+                </tr>
+            </thead>
+            <tbody>
+                    { comparisonRows.map((row, key) => {
+                        return <tr key={key}>
+                            <td className={"text-slate-200 py-4 px-2 text-center border border-slate-400"}>{row[0]}</td>
+                            <td className={"text-slate-200 py-4 px-2 text-center border border-slate-400"}>{row[1]}</td>
+                            <td className={"text-slate-200 py-4 px-2 text-center border border-slate-400"}>{row[2]}</td>
+                        </tr>
+                    }) }
+            </tbody>
+        </table>
+    </div>
 });


### PR DESCRIPTION
Make the Heroku comparison table scrollable, also reduce the X margin on the table so that it fills more space to line up under the header.